### PR TITLE
[Refactor] 캠페인 인모메리 캐시에 SWR 적용

### DIFF
--- a/backend/src/campaign/campaign-cron.service.ts
+++ b/backend/src/campaign/campaign-cron.service.ts
@@ -41,7 +41,7 @@ export class CampaignCronService {
     try {
       // 0. Redis에서 한번만 로드
       const cachedCampaigns =
-        await this.campaignCacheRepository.getAllCampaigns();
+        await this.campaignCacheRepository.getAllCampaigns({ allowStale: false });
       this.logger.log(`Redis 캠페인 ${cachedCampaigns.length}개 로드`);
 
       // 1. 종료일 지난 캠페인 ENDED (Redis First) - 비딩 차단 최우선
@@ -207,7 +207,7 @@ export class CampaignCronService {
   }> {
     this.logger.log('수동 Lazy Reset 시작');
     const cachedCampaigns =
-      await this.campaignCacheRepository.getAllCampaigns();
+      await this.campaignCacheRepository.getAllCampaigns({ allowStale: false });
 
     const stopped = await this.stopExpiredCampaigns(cachedCampaigns);
     const paused = await this.pauseOverspentCampaigns(cachedCampaigns);

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -1,9 +1,9 @@
 import {
-  Injectable,
-  NotFoundException,
   BadRequestException,
   ForbiddenException,
+  Injectable,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { InjectQueue } from '@nestjs/bullmq';
@@ -15,13 +15,13 @@ import { CampaignRepository } from './repository/campaign.repository.interface';
 import { CreateCampaignDto } from './dto/create-campaign.dto';
 import { UpdateCampaignDto } from './dto/update-campaign.dto';
 import { GetCampaignListDto } from './dto/get-campaign-list.dto';
-import { CampaignStatus, CampaignEntity } from './entities/campaign.entity';
+import { CampaignEntity, CampaignStatus } from './entities/campaign.entity';
 import { TagEntity } from '../tag/entities/tag.entity';
 import type {
-  CampaignWithTags,
-  CampaignWithStats,
   CachedCampaign,
   CachedCampaignWithoutSpent,
+  CampaignWithStats,
+  CampaignWithTags,
 } from './types/campaign.types';
 import { AVAILABLE_TAGS } from '../common/constants';
 import { UserRepository } from 'src/user/repository/user.repository.interface';
@@ -42,7 +42,6 @@ export class CampaignService {
     private readonly campaignRepository: CampaignRepository,
     private readonly userRepository: UserRepository,
     private readonly campaignCacheRepository: CampaignCacheRepository,
-    // private readonly creditHistoryRepository: CreditHistoryRepository, // TODO: 이거는 언제 쓰이는 걸까
     private readonly logRepository: LogRepository,
     @InjectDataSource() private readonly dataSource: DataSource,
     @InjectQueue('embedding-queue')

--- a/backend/src/campaign/campaign.service.ts
+++ b/backend/src/campaign/campaign.service.ts
@@ -133,6 +133,7 @@ export class CampaignService {
 
     // 트랜잭션으로 캠페인 생성과 크레딧 차감을 원자적으로? 처리
     return await this.dataSource.transaction(async (manager) => {
+      // TODO: Datasource가 아닌 InjectRepository로 받은 인스턴스로 쿼리를 날리고있어 트랜잭션에 안묶이므로 수정필요
       const campaign = await this.campaignRepository.create(
         userId,
         dto,

--- a/backend/src/campaign/repository/campaign.cache.repository.interface.ts
+++ b/backend/src/campaign/repository/campaign.cache.repository.interface.ts
@@ -49,7 +49,9 @@ export abstract class CampaignCacheRepository {
   abstract existsCampaignCacheById(id: string): Promise<boolean>;
 
   // RTB 비딩용: 모든 캠페인 조회 (Redis에서)
-  abstract getAllCampaigns(): Promise<CachedCampaign[]>;
+  abstract getAllCampaigns(options?: {
+    allowStale?: boolean;
+  }): Promise<CachedCampaign[]>;
 
   // 일일 예산 리셋용 (자정 정산)
   abstract resetDailySpentCache(id: string): Promise<void>;

--- a/backend/src/campaign/repository/redis-campaign.cache.repository.ts
+++ b/backend/src/campaign/repository/redis-campaign.cache.repository.ts
@@ -7,8 +7,8 @@ import {
   CachedCampaignWithoutSpent,
 } from '../types/campaign.types';
 import {
-  REDIS_INCREMENT_SPENT_SCRIPT,
   REDIS_DECREMENT_SPENT_SCRIPT,
+  REDIS_INCREMENT_SPENT_SCRIPT,
 } from '../scripts/lua-script';
 
 @Injectable()
@@ -18,10 +18,15 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
   private readonly CAMPAIGN_KEYS_SET = 'campaign:keys';
   private readonly CAMPAIGN_CACHE_TTL = 60 * 60 * 24;
   private readonly ALL_CAMPAIGNS_CACHE_TTL_MS = 10_000; // RTB decision hot path (짧은 TTL로 Redis SCAN/JSON.GET 비용 완화)
+  private readonly ALL_CAMPAIGNS_CACHE_TTL_JITTER_RATIO = 0.2; // multi-instance stampede 완화 (±20%)
+  private readonly ALL_CAMPAIGNS_CACHE_SWR_MS = 3_000; // stale-while-revalidate window
+
   private allCampaignsCache: {
     value: CachedCampaign[];
-    expiresAtMs: number;
+    freshUntilMs: number;
+    staleUntilMs: number;
   } | null = null;
+
   private allCampaignsInFlight: Promise<CachedCampaign[]> | null = null;
 
   constructor(
@@ -269,17 +274,58 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
   /**
    * Redis에서 전체 캠페인 조회
    */
-  async getAllCampaigns(): Promise<CachedCampaign[]> {
+  async getAllCampaigns(options?: {
+    allowStale?: boolean;
+  }): Promise<CachedCampaign[]> {
     const nowMs = Date.now();
+    const allowStale = options?.allowStale ?? true;
 
     const cached = this.allCampaignsCache;
-    if (cached && cached.expiresAtMs > nowMs) {
+    if (cached && cached.freshUntilMs > nowMs) {
       return cached.value;
     }
 
+    // 현재 반환대기중인 Promise가 없으면 백그라운드 refresh 요청하고 stale값 반환
+    if (allowStale && cached && cached.staleUntilMs > nowMs) {
+      if (!this.allCampaignsInFlight) {
+        void this.refreshAllCampaignsCache().catch(() => {
+          // refresh 내부에서 로깅하므로 여기서는 noop
+        });
+      }
+      return cached.value;
+    }
+
+    // 반환대기중인 Promise가 있으면 해당 Promise를 반환받음
     if (this.allCampaignsInFlight) {
       return this.allCampaignsInFlight;
     }
+
+    return this.refreshAllCampaignsCache();
+  }
+
+  private getCampaignCacheKey(id: string): string {
+    return `${this.KEY_PREFIX}${id}`;
+  }
+
+  private computeJitteredTtlMs(baseTtlMs: number): number {
+    const ratio = Math.max(0, this.ALL_CAMPAIGNS_CACHE_TTL_JITTER_RATIO);
+    if (ratio === 0) return baseTtlMs;
+
+    const min = Math.floor(baseTtlMs * (1 - ratio));
+    const max = Math.ceil(baseTtlMs * (1 + ratio));
+    const clampedMin = Math.max(0, min);
+    const clampedMax = Math.max(clampedMin, max);
+    return (
+      clampedMin + Math.floor(Math.random() * (clampedMax - clampedMin + 1))
+    );
+  }
+
+  private async refreshAllCampaignsCache(): Promise<CachedCampaign[]> {
+    if (this.allCampaignsInFlight) {
+      return this.allCampaignsInFlight;
+    }
+
+    const previous = this.allCampaignsCache;
 
     const work = (async () => {
       try {
@@ -288,6 +334,7 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
         let keys = await this.ioredisClient.smembers(this.CAMPAIGN_KEYS_SET);
         keys = keys.filter((k) => k.startsWith(this.KEY_PREFIX));
 
+        // 키 인덱스가 없으면 SCAN으로 전수조사
         if (keys.length === 0) {
           const pattern = `${this.KEY_PREFIX}*`;
           const scannedKeys: string[] = [];
@@ -372,6 +419,7 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
         return campaigns;
       } catch (error) {
         this.logger.error('모든 캠페인 조회 실패', error);
+        if (previous) return previous.value;
         return [];
       } finally {
         this.allCampaignsInFlight = null;
@@ -379,17 +427,13 @@ export class RedisCampaignCacheRepository implements CampaignCacheRepository {
     })();
 
     this.allCampaignsInFlight = work;
-
     const campaigns = await work;
-    this.allCampaignsCache = {
-      value: campaigns,
-      expiresAtMs: Date.now() + this.ALL_CAMPAIGNS_CACHE_TTL_MS,
-    };
+
+    const ttlMs = this.computeJitteredTtlMs(this.ALL_CAMPAIGNS_CACHE_TTL_MS);
+    const freshUntilMs = Date.now() + ttlMs;
+    const staleUntilMs = freshUntilMs + this.ALL_CAMPAIGNS_CACHE_SWR_MS;
+    this.allCampaignsCache = { value: campaigns, freshUntilMs, staleUntilMs };
 
     return campaigns;
-  }
-
-  private getCampaignCacheKey(id: string): string {
-    return `${this.KEY_PREFIX}${id}`;
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- close: #

---

## 1. PR 유형
- [ ] 🐛 버그 수정 (Bug Fix)
- [ ] ✨ 새로운 기능 (New Feature)
- [x] ♻️ 리팩토링 (Refactoring)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] ⚙️ 설정/빌드 변경 (Chore)

---

## 2. 작업 배경 및 목적
- **기존 상태:** `backend/src/campaign/repository/redis-campaign.cache.repository.ts`의 `RedisCampaignCacheRepository.getAllCampaigns()`는 in-memory TTL 캐시 + per-process in-flight(Promise) 병합으로 Redis `JSON.GET` 다건 조회를 완화합니다. TTL이 만료된 시점에는 refresh를 동기적으로 기다리는(블로킹) 구조여서, refresh 지연이 곧바로 요청 tail(p95/p99) 증가로 전파될 수 있습니다. TTL이 고정(예: 10s)인 경우, 멀티 인스턴스에서 만료 경계가 수렴해 같은 타이밍에 refresh가 집중될 수 있습니다.
- **문제점:** TTL 만료 경계에서 refresh가 느려지는 구간에 요청이 누적되면 dropped iteration/timeout과 tail latency 증가가 발생할 수 있습니다. in-flight 병합은 동일 프로세스 내 중복 refresh만 억제하므로, 멀티 인스턴스의 동시 refresh는 별도 제어가 필요합니다.
- **해결 목표:** stale-while-revalidate(SWR)로 stale을 즉시 반환하고 refresh를 백그라운드로 수행해 TTL 경계의 tail latency를 완화합니다. TTL에 지터(jitter)를 적용해 refresh 타이밍을 분산시켜 스탬피드 가능성을 낮춥니다. 정합성이 우선인 크론/운영 경로에서는 stale 반환을 금지할 수 있도록 호출 정책을 분리합니다.

---

## 3. 상세 변경 내역 및 동작 흐름

### A. `getAllCampaigns()`에 jitter + SWR 도입 (stale 즉시 반환 + 백그라운드 refresh)
- **진입점 및 초기 조건:** 진입점은 `backend/src/campaign/repository/redis-campaign.cache.repository.ts`의 `RedisCampaignCacheRepository.getAllCampaigns(options?)`이며, RTB decision 경로의 캠페인 후보 로딩 단계에서 호출됩니다. 캐시 엔트리는 `this.allCampaignsCache`에 `{ value, freshUntilMs, staleUntilMs }` 형태로 유지되고, 단일 프로세스 내 refresh는 `this.allCampaignsInFlight`(Promise)로 병합됩니다.

```ts
type AllCampaignsCacheEntry = {
  value: CachedCampaign[];
  freshUntilMs: number;
  staleUntilMs: number;
};
```

- **단계별 제어 흐름:** `allowStale` 기본값은 `true`이며, 호출부에서 `false`로 오버라이드할 수 있습니다. 아래 순서로 분기됩니다.

```ts
// 요약: fresh는 즉시 반환, stale은 즉시 반환 + 백그라운드 refresh, expired는 refresh를 대기
if (cache && cache.freshUntilMs > now) return cache.value;
if (cache && allowStale && cache.staleUntilMs > now) {
  if (!this.allCampaignsInFlight) void this.refreshAllCampaignsCache();
  return cache.value;
}
return this.allCampaignsInFlight ?? (this.allCampaignsInFlight = this.refreshAllCampaignsCache());
```

1. 캐시가 있고 `freshUntilMs > now`이면 `value`를 즉시 반환합니다.
2. 캐시가 있고 `staleUntilMs > now`이며 `allowStale=true`이면 `value`를 즉시 반환합니다.
3. 2의 stale 반환 케이스에서 `allCampaignsInFlight`가 비어있으면 `refreshAllCampaignsCache()`를 백그라운드로 트리거합니다.
4. `staleUntilMs <= now`이면 stale을 반환하지 않고 refresh를 기다립니다.
5. `refreshAllCampaignsCache()`는 Redis에서 캠페인 키 목록을 읽고, pipeline으로 `JSON.GET` 다건 조회 후 `JSON.parse`로 `CachedCampaign[]`를 구성합니다.
6. refresh 완료 후 `freshUntilMs`는 `freshTTLMs`에 `±jitter`를 적용해 산출하고, `staleUntilMs = freshUntilMs + staleTTLMs`로 설정합니다.
7. refresh 중 오류가 발생하면 이전 캐시가 있으면 이전 `value`를 반환합니다(stale-if-error).

- **데이터 상태 변이:** 캐시 엔트리 단위가 `value`만 갖던 구조에서 `{ value, freshUntilMs, staleUntilMs }`로 변경됩니다. TTL 만료 경계에서 refresh 대기가 stale 즉시 반환으로 대체되며, refresh는 백그라운드로 진행됩니다(단, stale window를 초과하면 다시 동기 refresh로 전환). TTL 지터로 프로세스별 refresh 발생 시점이 분산됩니다.

- **최종 반환 및 종료 상태:** `fresh` 구간은 즉시 반환합니다. `stale` 구간(`allowStale=true`)은 stale을 즉시 반환하고 refresh는 백그라운드에서 수행합니다(최대 1개 in-flight). `expired` 구간 또는 `allowStale=false`는 refresh 결과를 대기 후 반환합니다.

### B. 호출부 정책 분리: 크론/운영 경로는 fresh 강제(`allowStale: false`)
- **진입점 및 초기 조건:** 진입점은 `backend/src/campaign/campaign-cron.service.ts`입니다. 크론/운영 경로는 캠페인 목록을 기준으로 예산/상태를 변경하므로 stale 반환을 허용하면 누락/중복 처리의 원인이 될 수 있습니다.
- **단계별 제어 흐름:**

1. 크론/수동 리셋에서 `getAllCampaigns({ allowStale: false })`로 호출합니다.
2. stale 구간이라도 캐시를 반환하지 않고 refresh 결과(fresh)를 대기한 뒤 목록을 사용합니다.
3. 이를 위해 `CampaignCacheRepository.getAllCampaigns(options?)`의 옵션을 확장합니다.

```ts
await this.campaignCacheRepository.getAllCampaigns({ allowStale: false });
```
- **데이터 상태 변이:** 동일 메서드에서 호출부 옵션(`allowStale`)으로 "RTB는 tail 완화"와 "크론은 정합성 우선"을 분리합니다.
- **최종 반환 및 종료 상태:** 크론/운영 경로는 stale 반환 없이 최신 목록을 기준으로 동작합니다.

---

## 4. 스크린샷 (선택)
- N/A

## 5. 테스트 및 검증 방법
- **테스트 환경:** 로컬 backend 구동, k6 부하 테스트(`constant-arrival-rate`)
- **입력 시나리오:**
1. 동일 조건에서 SWR 적용 전/후를 각각 실행합니다.
2. 커맨드:

```bash
BASE_URL=http://localhost:3000 \
SCENARIO=constant-arrival-rate \
RATE=30 DURATION=3m SLEEP=0 \
BLOG_KEY=test-blog POST_URL=http://127.0.0.1/posts/1 \
k6 run k6/http/rtb-decision-random-pool.js
```
- **출력 검증:** `http_req_failed` / `errors`가 0%인지 확인하고, `http_req_duration p(95)`가 300ms 임계치를 넘지 않는지 확인하며, TTL 경계 구간에서 dropped iteration이 발생하지 않는지 확인합니다.

---

## 6. 리뷰어 참고 사항 (선택)
- **특이 구현 사항:** SWR stale 구간에서는 요청을 블로킹하지 않고 stale을 즉시 반환하며, refresh는 백그라운드로 수행합니다. refresh 실패 시 이전 캐시가 존재하면 이전 값을 반환합니다(stale-if-error).
- **파급 효과:** RTB 경로에서 최대 stale window 동안 stale 데이터가 반환될 수 있습니다. refresh 실패가 지속되면 stale 반환이 길어질 수 있으므로, 에러/지연에 대한 모니터링(로그/메트릭) 지점이 필요합니다. `allowStale: false`가 필요한 호출부가 더 있는지(정합성 영향 경로) 점검이 필요합니다.

---

## 7. 체크리스트
- [x] 코드가 프로젝트의 코딩 스타일 가이드를 준수합니다.
- [x] 변경 사항에 대한 테스트를 실행해 동작을 검증했습니다. (근거: k6 부하테스트 실행)
- [ ] 관련된 문서(README, API 명세 등)를 업데이트했습니다.
